### PR TITLE
Add wait_for_customization option to provisioning tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Examples
             ip: 192.168.1.178
             netmask: 255.255.255.0
             gateway: 192.168.1.1
-        hadrware:
+        hardware:
           num_cpus: 2
           memory_mb: 2048
 
@@ -68,7 +68,7 @@ Examples
             ip: 10.0.0.178
             netmask: 255.255.255.0
             gateway: 10.0.0.1
-        hadrware:
+        hardware:
           num_cpus: 2
           memory_mb: 16384
           nested_virt: yes
@@ -96,7 +96,7 @@ Examples
             ip: 10.0.0.179
             netmask: 255.255.255.0
             gateway: 10.0.0.1
-        hadrware:
+        hardware:
           num_cpus: 2
           memory_mb: 16384
           nested_virt: yes

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -193,6 +193,7 @@
         validate_certs: "{{ vmware_vm_provisioning_vm.validate_certs | default(vmware_vm_provisioning_validate_certs | default(omit)) }}"
         vapp_properties: "{{ vmware_vm_provisioning_vm.vapp_properties | default(vmware_vm_provisioning_vapp_properties | default(omit)) }}"
         wait_for_ip_address: "{{ vmware_vm_provisioning_vm.wait_for_ip_address | default(vmware_vm_provisioning_wait_for_ip_address | default(omit)) }}"
+        wait_for_customization: "{{ vmware_vm_provisioning_vm.wait_for_customization | default(vmware_vm_provisioning_wait_for_customization | default(omit)) }}"
       when: >
         (
             'state' not in vmware_vm_provisioning_vm or


### PR DESCRIPTION
Hello! Thank you for your work on this role, it's very handy. I work with a lot of Windows servers and use vmware_guest customization to join them to an Active Directory domain. They don't pick up a lot of important information until after they've joined the domain and rebooted so it's nice to use the wait_for_customization option in the vmware_guest module. This PR adds that option to the provisioning task (also fixes a typo in the README examples). Thanks again!